### PR TITLE
Function variable name analyzer

### DIFF
--- a/src/main/java/wasm/analysis/WasmAnalysis.java
+++ b/src/main/java/wasm/analysis/WasmAnalysis.java
@@ -127,13 +127,13 @@ public class WasmAnalysis implements AnalysisState {
 			ValType[] nonParamLocals = module.getFunctionLocals(funcidx);
 			if (nonParamLocals == null) {
 				/* import */
-				functions.add(new WasmFuncSignature(params, returns, name, startAddress));
+				functions.add(new WasmFuncSignature(funcidx, params, returns, name, startAddress));
 			} else {
 				ValType[] locals = new ValType[params.length + nonParamLocals.length];
 
 				System.arraycopy(params, 0, locals, 0, params.length);
 				System.arraycopy(nonParamLocals, 0, locals, params.length, nonParamLocals.length);
-				functions.add(new WasmFuncSignature(params, returns, name, startAddress, endAddress, locals));
+				functions.add(new WasmFuncSignature(funcidx, params, returns, name, startAddress, endAddress, locals));
 			}
 		}
 		return functions;

--- a/src/main/java/wasm/analysis/WasmFuncSignature.java
+++ b/src/main/java/wasm/analysis/WasmFuncSignature.java
@@ -4,12 +4,17 @@ import ghidra.program.model.address.Address;
 import wasm.format.WasmEnums.ValType;
 
 public class WasmFuncSignature {
+	private int funcidx;
 	private ValType[] params;
 	private ValType[] returns;
 	private String name;
 	private Address startAddr;
 	private Address endAddr; // address of last byte in the function (inclusive)
 	private ValType[] locals;
+
+	public int getFuncidx() {
+		return funcidx;
+	}
 
 	public ValType[] getParams() {
 		return params;
@@ -39,15 +44,17 @@ public class WasmFuncSignature {
 		return locals == null;
 	}
 
-	public WasmFuncSignature(ValType[] paramTypes, ValType[] returnTypes, String name, Address addr) {
+	public WasmFuncSignature(int funcidx, ValType[] paramTypes, ValType[] returnTypes, String name, Address addr) {
+		this.funcidx = funcidx;
 		this.name = name;
 		this.startAddr = addr;
 		this.params = paramTypes;
 		this.returns = returnTypes;
 	}
 
-	public WasmFuncSignature(ValType[] paramTypes, ValType[] returnTypes, String name, Address startAddr, Address endAddr, ValType[] locals) {
-		this(paramTypes, returnTypes, name, startAddr);
+	public WasmFuncSignature(int funcidx, ValType[] paramTypes, ValType[] returnTypes, String name, Address startAddr,
+			Address endAddr, ValType[] locals) {
+		this(funcidx, paramTypes, returnTypes, name, startAddr);
 		this.endAddr = endAddr;
 		this.locals = locals;
 	}

--- a/src/main/java/wasm/analysis/WasmFunctionVariableNameAnalyzer.java
+++ b/src/main/java/wasm/analysis/WasmFunctionVariableNameAnalyzer.java
@@ -1,0 +1,244 @@
+package wasm.analysis;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalysisPriority;
+import ghidra.app.services.AnalyzerType;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.lang.Processor;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionIterator;
+import ghidra.program.model.listing.LocalVariableImpl;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.Variable;
+import ghidra.program.model.pcode.HighFunction;
+import ghidra.program.model.pcode.HighLocal;
+import ghidra.program.model.pcode.HighSymbol;
+import ghidra.program.model.pcode.HighVariable;
+import ghidra.program.model.pcode.Varnode;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.util.Msg;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.exception.DuplicateNameException;
+import ghidra.util.exception.InvalidInputException;
+import ghidra.util.task.TaskMonitor;
+import wasm.format.WasmEnums.ValType;
+import wasm.format.sections.WasmNameSection;
+import wasm.format.sections.structures.WasmNameSubsection.WasmNameSubsectionId;
+
+public class WasmFunctionVariableNameAnalyzer extends AbstractAnalyzer {
+
+	private final static int MAX_LOCAL = 4096;
+
+	private final static String DESCRIPTION = "Extract and apply names contained in the '.name' section to functions' local variables.";
+
+	private DecompInterface dif;
+	/** offset to the first local in the register space **/
+	private long baseLocalOffset;
+
+	public WasmFunctionVariableNameAnalyzer() {
+		super("Wasm variable name Analyzer", DESCRIPTION, AnalyzerType.FUNCTION_ANALYZER);
+		setPriority(AnalysisPriority.DATA_TYPE_PROPOGATION);
+		setDefaultEnablement(true);
+		setSupportsOneTimeAnalysis();
+	}
+
+	@Override
+	public boolean canAnalyze(Program program) {
+		return program.getLanguage().getProcessor().equals(Processor.findOrPossiblyCreateProcessor("Webassembly"));
+	}
+
+	protected DecompInterface getInitializedDecompInterface(Program prog) {
+		if (dif == null) {
+			dif = new DecompInterface();
+			dif.openProgram(prog);
+		}
+		return dif;
+	}
+
+	protected void cleanup() {
+		if (dif != null) {
+			dif.dispose();
+			dif = null;
+		}
+	}
+
+	@Override
+	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
+			throws CancelledException {
+		WasmAnalysis state = WasmAnalysis.getState(program);
+		WasmNameSection nameSection = state.getModule().getNameSection();
+		if (nameSection == null) {
+			return true;
+		}
+
+		// skip if the name section doesn't contain a NAME_LOCAL entry.
+		if (!nameSection.hasNameSubSection(WasmNameSubsectionId.NAME_LOCAL)) {
+			return true;
+		}
+
+		baseLocalOffset = program.getRegister("l0q").getOffset();
+
+		try {
+			FunctionIterator iter = program.getFunctionManager().getFunctions(set, true);
+			while (iter.hasNext()) {
+				if (monitor.isCancelled()) {
+					break;
+				}
+
+				Function func = iter.next();
+				WasmFuncSignature funcSig = state.getFunctionByAddress(func.getEntryPoint());
+				if (funcSig == null) {
+					// this should never happen
+					continue;
+				}
+				Map<Long, String> localNames = nameSection.getLocalNames(funcSig.getFuncidx());
+				if (localNames == null || localNames.isEmpty()) {
+					continue;
+				}
+
+				Map<Long, String> filteredLocalNames = filterNewVariables(func, funcSig, localNames);
+				if (filteredLocalNames.isEmpty()) {
+					// skip if there is no name to apply after filtering
+					continue;
+				}
+				applyLocalNames(program, func, funcSig, filteredLocalNames);
+			}
+		} finally {
+			cleanup();
+		}
+		return true;
+	}
+
+	protected Map<Long, String> filterNewVariables(Function func, WasmFuncSignature funcSig,
+			Map<Long, String> localNames) {
+		// compute variable names and local indexes that are already assigned
+		Set<String> usedVarNames = new HashSet<>();
+		Set<Long> usedLocalIndexes = new HashSet<>();
+		for (Variable var : func.getLocalVariables()) {
+			usedVarNames.add(var.getName());
+			Varnode vn = var.getFirstStorageVarnode();
+			if (vn.isRegister()) {
+				long localIndex = registerToLocal(vn.getOffset());
+				if (localIndex != -1) {
+					usedLocalIndexes.add(localIndex);
+				}
+			}
+		}
+
+		int paramsCount = funcSig.getParams().length;
+
+		Map<Long, String> filteredLocalNames = new HashMap<>();
+		for (Entry<Long, String> entry : localNames.entrySet()) {
+			long localIndex = entry.getKey();
+			String localName = entry.getValue();
+			// skip if this entry corresponds to a function parameter
+			if (localIndex < paramsCount) {
+				continue;
+			}
+
+			// there are at most 4096 locals (as defined in the slaspec file).
+			if (localIndex >= MAX_LOCAL) {
+				continue;
+			}
+
+			// skip if there is already a variable defined for this local
+			if (usedLocalIndexes.contains(localIndex)) {
+				continue;
+			}
+
+			// skip if there is already a variable with the same name
+			if (usedVarNames.contains(localName)) {
+				continue;
+			}
+			filteredLocalNames.put(localIndex, localName);
+		}
+
+		return filteredLocalNames;
+	}
+
+	protected void applyLocalNames(Program program, Function function, WasmFuncSignature funcSig,
+			Map<Long, String> localNames) {
+		Set<Long> localIndexes = new HashSet<>(localNames.keySet()); // make a copy as found elements will be removed
+		Map<Long, Long> localsFirstUse = getLocalFirstUses(program, function, localIndexes);
+
+		ValType[] localsTypes = funcSig.getLocals();
+
+		int paramCount = funcSig.getParams().length;
+
+		for (Entry<Long, String> entry : localNames.entrySet()) {
+			long localIndex = entry.getKey();
+			String varName = entry.getValue();
+			long firstUse = localsFirstUse.getOrDefault(localIndex, 0l);
+			DataType dt = localsTypes[(int) (localIndex - paramCount)].asDataType();
+			Register reg = program.getLanguage().getRegister(getRegisterName(localIndex, dt.getLength()));
+
+			try {
+				LocalVariableImpl var = new LocalVariableImpl(varName, (int) firstUse, dt, reg, program);
+				function.addLocalVariable(var, SourceType.ANALYSIS);
+			} catch (InvalidInputException | DuplicateNameException e) {
+				Msg.error(this, "Failed to apply variable name '" + varName + "' to " + function.getName(), e);
+			}
+		}
+	}
+
+	protected Map<Long, Long> getLocalFirstUses(Program prog, Function func, Set<Long> localIndexSearch) {
+		// Note:
+		// We retrieve first uses of local using the decompiler to make sure
+		// that it picks up the new variable name. Otherwise, the variable name is only
+		// shown in listing.
+
+		Map<Long, Long> res = new HashMap<>();
+		// create or reuse existing DecompInterface
+		DecompInterface decomp = getInitializedDecompInterface(prog);
+		// decompile the function
+		HighFunction hf = decomp.decompileFunction(func, 10, null).getHighFunction();
+
+		// loop through HighSymbol to retrieve variable corresponding to a local
+		Iterator<HighSymbol> it = hf.getLocalSymbolMap().getSymbols();
+		while (it.hasNext() && !localIndexSearch.isEmpty()) {
+			HighSymbol hs = it.next();
+			HighVariable hv = hs.getHighVariable();
+			if (hv == null) {
+				continue;
+			}
+			Varnode vn = hv.getRepresentative();
+			if (vn.isRegister() && hv instanceof HighLocal) {
+				long localIndex = registerToLocal(vn.getOffset());
+				// if this is one of the locals we are looking for
+				if (localIndexSearch.contains(localIndex)) {
+					HighLocal hl = (HighLocal) hv;
+					long useOffset = hl.getPCAddress().getOffset() - func.getEntryPoint().getOffset();
+					res.put(localIndex, useOffset);
+					// no need to keep looking for this local
+					localIndexSearch.remove(localIndex);
+				}
+
+			}
+		}
+		return res;
+	}
+
+	protected long registerToLocal(long registerOffset) {
+		long localIndex = (registerOffset - baseLocalOffset) / 8;
+		if (localIndex < 0 || localIndex >= MAX_LOCAL) {
+			return -1;
+		}
+		return localIndex;
+	}
+
+	protected String getRegisterName(long localIndex, int dataSize) {
+		return "l" + localIndex + (dataSize == 8 ? "q" : "");
+	}
+
+}

--- a/src/main/java/wasm/format/sections/WasmNameSection.java
+++ b/src/main/java/wasm/format/sections/WasmNameSection.java
@@ -75,6 +75,17 @@ public class WasmNameSection extends WasmCustomSection {
 		return ((WasmNameMapSubsection) subsection).getName(idx);
 	}
 
+	public Map<Long, String> getLocalNames(int funcidx) {
+		WasmNameSubsection subsection = subsectionMap.get(WasmNameSubsectionId.NAME_LOCAL);
+		if (subsection == null)
+			return null;
+		return ((WasmNameLocalSubsection) subsection).getLocalNames(funcidx);
+	}
+
+	public boolean hasNameSubSection(WasmNameSubsectionId nameSubsectionId) {
+		return subsectionMap.containsKey(nameSubsectionId);
+	}
+
 	@Override
 	public String getName() {
 		return ".name";

--- a/src/main/java/wasm/format/sections/structures/WasmNameIndirectMap.java
+++ b/src/main/java/wasm/format/sections/structures/WasmNameIndirectMap.java
@@ -42,6 +42,13 @@ public class WasmNameIndirectMap implements StructConverter {
 		return subMap.getEntry(idx2);
 	}
 
+	public Map<Long, String> getNameMapping(long idx1) {
+		WasmNameMap subMap = map.get(idx1);
+		if (subMap == null)
+			return null;
+		return subMap.getMap();
+	}
+
 	@Override
 	public DataType toDataType() throws DuplicateNameException, IOException {
 		StructureBuilder builder = new StructureBuilder("indirectnamemap");

--- a/src/main/java/wasm/format/sections/structures/WasmNameLocalSubsection.java
+++ b/src/main/java/wasm/format/sections/structures/WasmNameLocalSubsection.java
@@ -1,6 +1,7 @@
 package wasm.format.sections.structures;
 
 import java.io.IOException;
+import java.util.Map;
 
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.util.exception.DuplicateNameException;
@@ -17,6 +18,10 @@ public class WasmNameLocalSubsection extends WasmNameSubsection {
 
 	public String getLocalName(int funcidx, int localidx) {
 		return localNameMap.getEntry(funcidx, localidx);
+	}
+
+	public Map<Long, String> getLocalNames(int funcidx) {
+		return localNameMap.getNameMapping(funcidx);
 	}
 
 	@Override

--- a/src/main/java/wasm/format/sections/structures/WasmNameMap.java
+++ b/src/main/java/wasm/format/sections/structures/WasmNameMap.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.StructConverter;
@@ -18,7 +19,7 @@ public class WasmNameMap implements StructConverter {
 	private String structureName;
 	private LEB128 count;
 	private List<WasmAssoc> entries = new ArrayList<>();
-	private Map<Long, WasmName> map = new HashMap<>();
+	private Map<Long, String> map = new HashMap<>();
 
 	private static class WasmAssoc {
 		LEB128 idx;
@@ -33,15 +34,12 @@ public class WasmNameMap implements StructConverter {
 			assoc.idx = LEB128.readUnsignedValue(reader);
 			assoc.name = new WasmName(reader);
 			entries.add(assoc);
-			map.put(assoc.idx.asLong(), assoc.name);
+			map.put(assoc.idx.asLong(), assoc.name.getValue());
 		}
 	}
 
 	public String getEntry(long idx) {
-		WasmName result = map.get(idx);
-		if (result == null)
-			return null;
-		return result.getValue();
+		return map.get(idx);
 	}
 
 	@Override
@@ -54,5 +52,9 @@ public class WasmNameMap implements StructConverter {
 			builder.add(assoc.name, "name" + i);
 		}
 		return builder.toStructure();
+	}
+
+	public Map<Long, String> getMap() {
+		return map;
 	}
 }


### PR DESCRIPTION
This MR add a `WasmFunctionVariableNameAnalyzer` to detect and apply function variable names from the .name.locals section.

The .name.locals sections seems to be used mostly when building from .wat format.

[Here](https://github.com/nneonneo/ghidra-wasm-plugin/files/7289524/fibonacci-project.zip) is a sample for testing. It can be modified with https://webassembly.studio/

PS: the `buff` variable in this sample project isn't shown in the decompiler view because it is optimized out, but it should still appear in the listing.

