### PR TITLE
Add support for DWARF type import.

### DIFF
--- a/data/languages/Webassembly.dwarf
+++ b/data/languages/Webassembly.dwarf
@@ -1,0 +1,6 @@
+<dwarf>
+	<register_mappings>
+		<!-- This is a dummy file to prevent "No DWARF to Ghidra register mappings" error-->
+		<register_mapping dwarf="3000" ghidra="SP" stackpointer="true"/>
+	</register_mappings>
+</dwarf>

--- a/data/languages/Webassembly.ldefs
+++ b/data/languages/Webassembly.ldefs
@@ -13,5 +13,6 @@
     <description>Webassembly Language Module</description>
     <compiler name="default" spec="Webassembly.cspec" id="default"/>
     <compiler name="pos-stack" spec="Webassembly-pos-stack.cspec" id="pos-stack"/>
+    <external_name tool="DWARF.register.mapping.file" name="Webassembly.dwarf"/>
   </language> 
 </language_definitions>

--- a/src/main/java/wasm/WasmLoader.java
+++ b/src/main/java/wasm/WasmLoader.java
@@ -59,6 +59,7 @@ import wasm.format.WasmModule;
 import wasm.format.sections.WasmNameSection;
 import wasm.format.sections.WasmSection;
 import wasm.format.sections.WasmSection.WasmSectionId;
+import wasm.format.sections.WasmUnknownCustomSection;
 import wasm.format.sections.structures.WasmDataSegment;
 import wasm.format.sections.structures.WasmElementSegment;
 import wasm.format.sections.structures.WasmExportEntry;
@@ -71,11 +72,13 @@ import wasm.format.sections.structures.WasmTableType;
 
 public class WasmLoader extends AbstractLibrarySupportLoader {
 
+	public final static String WEBASSEMBLY = "WebAssembly";
+
 	public final static long CODE_BASE = 0x80000000L;
 
 	@Override
 	public String getName() {
-		return "WebAssembly";
+		return WEBASSEMBLY;
 	}
 
 	@Override
@@ -141,7 +144,7 @@ public class WasmLoader extends AbstractLibrarySupportLoader {
 
 	// #region Naming
 	private static Symbol createLabel(Program program, Address address, String name, Namespace namespace, SourceType sourceType) throws InvalidInputException {
-		if(name == null || name.isEmpty()) {
+		if (name == null || name.isEmpty()) {
 			name = "unnamed";
 		}
 
@@ -151,12 +154,12 @@ public class WasmLoader extends AbstractLibrarySupportLoader {
 		name = SymbolUtilities.replaceInvalidChars(name, true);
 		// Leave room for a suffix if necessary
 		int maxLen = SymbolUtilities.MAX_SYMBOL_NAME_LENGTH - 16;
-		if(name.length() > maxLen) {
+		if (name.length() > maxLen) {
 			name = name.substring(0, maxLen);
 		}
 		String newname = name;
 		int suffix = 0;
-		while(!program.getSymbolTable().getSymbols(newname, namespace).isEmpty()) {
+		while (!program.getSymbolTable().getSymbols(newname, namespace).isEmpty()) {
 			suffix++;
 			newname = name + "_" + suffix;
 		}
@@ -603,6 +606,35 @@ public class WasmLoader extends AbstractLibrarySupportLoader {
 		}
 	}
 
+	private MemoryBlock createCustomSectionBlock(Program program, FileBytes fileBytes, WasmUnknownCustomSection customSection, Address address)
+			throws Exception {
+		MemoryBlock block = program.getMemory().createInitializedBlock(customSection.getCustomName(), address, fileBytes, customSection.getContentOffset(), customSection.getCustomSize(), false);
+		block.setRead(true);
+		block.setWrite(false);
+		block.setExecute(false);
+		block.setSourceName("Wasm Module");
+		return block;
+	}
+
+	private void createCustomSections(Program program, FileBytes fileBytes, WasmModule module, TaskMonitor monitor) {
+		monitor.setMessage("Creating custom sections");
+		// start right after the module block
+		Address address = AddressSpace.OTHER_SPACE.getAddress(fileBytes.getSize());
+		for (WasmSection section : module.getCustomSections()) {
+			if (!(section instanceof WasmUnknownCustomSection)) {
+				continue;
+			}
+			WasmUnknownCustomSection customSection = (WasmUnknownCustomSection) section;
+			try {
+				monitor.setMessage("Creating custom section " + section.getName());
+				MemoryBlock block = createCustomSectionBlock(program, fileBytes, customSection, address);
+				address = address.add(block.getSize());
+			} catch (Exception e) {
+				Msg.error(this, "Failed to load Wasm Custom section " + customSection.getCustomName(), e);
+			}
+		}
+	}
+
 	@Override
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
 			Program program, TaskMonitor monitor, MessageLog log) throws IOException {
@@ -630,6 +662,8 @@ public class WasmLoader extends AbstractLibrarySupportLoader {
 			monitor.setMessage("Creating section " + section.getName());
 			createData(program, program.getListing(), moduleBlock.getStart().add(section.getSectionOffset()), section.toDataType());
 		}
+
+		createCustomSections(program, fileBytes, module, monitor);
 
 		loadFunctions(program, fileBytes, module, monitor);
 		loadTables(program, fileBytes, module, monitor);

--- a/src/main/java/wasm/analysis/WasmDWARFAnalyzer.java
+++ b/src/main/java/wasm/analysis/WasmDWARFAnalyzer.java
@@ -1,0 +1,20 @@
+package wasm.analysis;
+
+import ghidra.app.plugin.core.analysis.DWARFAnalyzer;
+import ghidra.app.util.bin.format.dwarf4.next.sectionprovider.DWARFSectionProviderFactory;
+import ghidra.program.model.listing.Program;
+import wasm.WasmLoader;
+
+public class WasmDWARFAnalyzer extends DWARFAnalyzer {
+
+	@Override
+	public boolean canAnalyze(Program program) {
+		String format = program.getExecutableFormat();
+
+		if (WasmLoader.WEBASSEMBLY.equals(format)
+				&& DWARFSectionProviderFactory.createSectionProviderFor(program) != null) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/wasm/format/sections/WasmUnknownCustomSection.java
+++ b/src/main/java/wasm/format/sections/WasmUnknownCustomSection.java
@@ -7,10 +7,12 @@ import ghidra.util.exception.DuplicateNameException;
 import wasm.format.StructureBuilder;
 
 public class WasmUnknownCustomSection extends WasmCustomSection {
-	byte[] contents;
+	private long contentOffset;
+	private byte[] contents;
 
 	public WasmUnknownCustomSection(BinaryReader reader) throws IOException {
 		super(reader);
+		contentOffset = reader.getPointerIndex();
 		contents = reader.readNextByteArray((int) getCustomSize());
 	}
 
@@ -22,6 +24,14 @@ public class WasmUnknownCustomSection extends WasmCustomSection {
 
 	@Override
 	public String getName() {
-		return ".custom";
+		return ".custom" + getCustomName(); // to avoid DataType conflict
+	}
+
+	public long getContentOffset() {
+		return contentOffset;
+	}
+
+	public byte[] getContents() {
+		return contents;
 	}
 }


### PR DESCRIPTION
This should allow datatype import from DWARF sections.

[Here](https://github.com/nneonneo/ghidra-wasm-plugin/files/7313374/dwarf.zip) is a minimal sample https://webassembly.studio/ project for testing.

As discussed in the original issue #1 only data types and function signatures are imported at the moment.

For the function signatures to be applied you need to select manually `DataType > {your_wasm_file} > Apply Function Data Types` from the `Data Type Manager` window.

Also if the `import function` option is left to true (the default value) an error windows will be displayed at the end of the analysis to inform that the function import failed.

Fixes #1 

