### PR TITLE
Add functions to symbol tree imports and exports.

### DIFF
--- a/src/main/java/wasm/analysis/WasmPreAnalyzer.java
+++ b/src/main/java/wasm/analysis/WasmPreAnalyzer.java
@@ -148,7 +148,7 @@ public class WasmPreAnalyzer extends AbstractAnalyzer {
 			monitor.incrementProgress(1);
 
 			WasmFuncSignature func = state.getFunctionByAddress(function.getEntryPoint());
-			if (func.isImport()) {
+			if (func == null || func.isImport()) {
 				continue;
 			}
 			WasmFunctionAnalysis funcAnalysis = state.getFunctionAnalysis(function);


### PR DESCRIPTION
This MR should make functions appear in the `Symbol Tree`'s `Exports` and `Imports` category.

I wasn't sure if you wanted to keep the "import/export" namespaces behavior so I left it untouched. I can modify this MR to remove it if needed.