### PR TITLE
Fix analyze_dyncalls.py compatibility issue with ghidra 10.1

### DIFF
--- a/ghidra_scripts/analyze_dyncalls.py
+++ b/ghidra_scripts/analyze_dyncalls.py
@@ -81,7 +81,7 @@ def renameDyncalls(calltype):
         name = "func_" + calltype + "_%d" % i
         if func.name.startswith("unnamed_function_"):
             func.setName(name, SourceType.ANALYSIS)
-        currentProgram.symbolTable.createSymbol(func.entryPoint, name, dynCallNamespace, SourceType.USER_DEFINED)
+        currentProgram.symbolTable.createLabel(func.entryPoint, name, dynCallNamespace, SourceType.USER_DEFINED)
 
 for function in currentProgram.functionManager.getFunctions(True):
     if function.parentNamespace.name == "export" and function.name.startswith("dynCall_"):


### PR DESCRIPTION
## Issue
Ghidra v10.1 removed `createSymbol(Address, String, Namespace, SourceType)` api (https://github.com/NationalSecurityAgency/ghidra/commit/d05a57ae1a90ae11a9f196dbcd48c74ff7252b34), which crashes the script.

## Fix
According to [this line](https://github.com/NationalSecurityAgency/ghidra/commit/d05a57ae1a90ae11a9f196dbcd48c74ff7252b34#diff-8df1a461bea224897255796fe5bc89a59ae6e099f4dc5c16bb4521b1ae05e695L103), simply use `createLabel(Address, String, Namespace, SourceType)` instead fixes it.
 