### PR TITLE
Fix NoSuchMethodError on Ghidra 12.2 in StructureBuilder

### DIFF
--- a/src/main/java/wasm/format/StructureBuilder.java
+++ b/src/main/java/wasm/format/StructureBuilder.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 
 import ghidra.app.util.bin.LEB128Info;
 import ghidra.app.util.bin.StructConverter;
+import ghidra.program.database.data.DataTypeUtilities;
 import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.CategoryPath;
 import ghidra.program.model.data.DataType;
@@ -35,6 +36,22 @@ public class StructureBuilder {
 		}
 
 		/**
+		 * Ghidra 12.2 removed CompositeDataTypeImpl.checkAncestry(DataType), so keep
+		 * the pre-12.2 behavior locally instead of linking against the removed
+		 * method.
+		 */
+		private void checkAncestryCompat(DataType dataType) {
+			if (this.equals(dataType)) {
+				throw new IllegalArgumentException(
+					"Data type " + getDisplayName() + " can't contain itself.");
+			}
+			if (DataTypeUtilities.isSecondPartOfFirst(dataType, this)) {
+				throw new IllegalArgumentException("Data type " + dataType.getDisplayName() +
+					" has " + getDisplayName() + " within it.");
+			}
+		}
+
+		/**
 		 * Add a component to this structure. This function does not repack the
 		 * structure after adding, in order to avoid quadratic behaviour when adding a
 		 * large number of structure elements. To ensure correct behaviour, the
@@ -46,7 +63,7 @@ public class StructureBuilder {
 
 			dataType = dataType.clone(dataMgr);
 
-			checkAncestry(dataType);
+			checkAncestryCompat(dataType);
 
 			DataTypeComponentImpl dtc;
 			int offset = structLength;


### PR DESCRIPTION
This fixes a Ghidra 12.2 compatibility issue in `StructureBuilder`.

## Problem
On Ghidra 12.2, loading a WebAssembly file fails with:

`java.lang.NoSuchMethodError: 'void wasm.format.StructureBuilder$SBStructure.checkAncestry(ghidra.program.model.data.DataType)'`

## Cause
`SBStructure.add()` was reusing an older inherited `checkAncestry(DataType)` call path that no longer exists in Ghidra 12.2.

## Fix
Replace that dependency with a local compatibility helper that preserves the old behavior using `DataTypeUtilities.isSecondPartOfFirst(...)`.

## Validation
Built successfully against Ghidra 12.2 using the extension Gradle build.
