### PR TITLE
fix: Fix crash when loading WASM with tags

### DIFF
--- a/src/main/java/wasm/format/WasmEnums.java
+++ b/src/main/java/wasm/format/WasmEnums.java
@@ -30,7 +30,8 @@ public class WasmEnums {
 		EXT_FUNCTION,
 		EXT_TABLE,
 		EXT_MEMORY,
-		EXT_GLOBAL
+		EXT_GLOBAL,
+		EXT_TAG
 	}
 
 	public enum ValType {


### PR DESCRIPTION
## Problem

I tried to load the `blazor.native.wasm` from a ahead-of-time compiled Blazor app into Ghidra. This resulted in no code being shown in the GUI and the error `ERROR (WasmLoader) Failed to load Wasm module java.lang.ArrayIndexOutOfBoundsException: index 4 out of bounds for length 4` in Ghidra's log.

## Cause

WASM seems to have added a [Tag Export entity](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/Tag), which is used for exception handling by Blazor. This tag is unknown to the extension and causes the error when trying to look it up in the `WasmExternalKind` enum.

## Fix

Adding a fifth element to the `WasmExternalKind` enum and recompiling the extension allowed me to successfully load and analyze the WASM file. I am not sure, if any other changes need to be made to further support exceptions.
